### PR TITLE
Fix Doc URLs, add user-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For GitHub paths, you can use `https://raw.githubusercontent.com/<username>/<rep
 If your readme contains front matter (either yaml or json), you can send
 additional data to the Modrinth API.
 
-All additional data can be found in the [Modrinth Docs](https://docs.modrinth.com/api-spec/#tag/projects/operation/modifyProject).  
+All additional data can be found in the [Modrinth Docs](https://docs.modrinth.com/#tag/projects/operation/modifyProject).  
 *Note: The `body` key should not be specified and will be ignored if it is.*
 
 ### Front Matter Format:

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: 'The path to the file to use for the description'
     required: false
     default: 'README.md'
+  project-name:
+    description: 'Used in the user-agent for identification purposes'
+    required: false
+    default: 'REPLACEME'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
   project-name:
     description: 'Used in the user-agent for identification purposes'
     required: false
-    default: 'REPLACEME'
+    default: '__unset'
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const main = async () => {
 
         //project-name for the user agent
         let user_agent = actions.getInput("project-name")
-        user_agent = user_agent == "REPLACEME" ? slug : `${user_agent} (${slug})`
+        user_agent = user_agent == '__unset' ? slug : `${user_agent} (${slug})`
 
         actions.info(`Loading ${actions.getInput('readme')}.`);
         const readme = await fs.readFile(actions.getInput('readme'), 'utf-8');

--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ const main = async () => {
         // Grab the slug if it's a url
         slug = slug.substring(slug.lastIndexOf('/') + 1);
 
+        //project-name for the user agent
+        let user_agent = actions.getInput("project-name")
+        user_agent = user_agent == "REPLACEME" ? slug : `${user_agent} (${slug})`
+
         actions.info(`Loading ${actions.getInput('readme')}.`);
         const readme = await fs.readFile(actions.getInput('readme'), 'utf-8');
 
@@ -42,7 +46,7 @@ const main = async () => {
             headers: {
                 Authorization: auth,
                 'content-type': 'Application/json',
-                'User-Agent': `${slug}` // https://docs.modrinth.com/#section/Identifiers Only a "good" user-agent but better than not supplying one. (using funnyboy-roks/modrinth-auto-desc GitHub Action) optionally could be included
+                'User-Agent': `${user_agent} via funnyboy-roks/modrinth-auto-desc`
             },
         });
 
@@ -52,18 +56,6 @@ const main = async () => {
             actions.error(JSON.stringify(await req.json(), null, 4));
             return;
         }
-
-        // Protoype retry code using modrinth's supplied rate limit headers.
-
-        // if (req.status == 429){ // Too many requests
-        //     let retryAfter = parseInt(req.headers.get('Retry-After'))
-        //     if (!isNaN(retryAfter)){
-        //         actions.warning(`Rate limit exceeded, backing off for ${retryAfter} seconds`)
-        //         await new Promise(resolve => setTimeout(resolve, retryAfter * 1000));
-        //     } else {
-        //         actions.setFailed("Rate limit exceeded, could not retry.")
-        //     }
-        // }
         
         actions.info('Modrinth response');
         const res = await req.text(); // Returns json, but not always, so text instead.


### PR DESCRIPTION
Hi there, I saw this project in Modtoberfest and saw I could add a few small things.

- I've changed the docs URLs to remove api-spec/ so they resolve 
- I added a header using the supplied slug. 
- I wanted to contribute a mechanism to take the rate limit supplied by the response in https://docs.modrinth.com/#section/Ratelimits 

but without a local testing environment I didn't feel comfortable leaving the rate limit mechanism in. It will need a way to send the request again, sendRequest() could be encapsulated and moved 